### PR TITLE
Automatic responding of UTE Teach-in

### DIFF
--- a/enocean/communicators/__init__.py
+++ b/enocean/communicators/__init__.py
@@ -1,1 +1,4 @@
 ''' Provider for different Communicator -classes for EnOcean. '''
+from enocean.communicators.communicator import Communicator
+from enocean.communicators.serialcommunicator import SerialCommunicator
+from enocean.communicators.tcpcommunicator import TCPCommunicator

--- a/enocean/communicators/communicator.py
+++ b/enocean/communicators/communicator.py
@@ -87,13 +87,18 @@ class Communicator(threading.Thread):
         # Unfortunately, all other messages received during this time are ignored.
         for i in range(0, 10):
             try:
-                p = self.receive.get(block=True, timeout=0.1)
+                packet = self.receive.get(block=True, timeout=0.1)
                 # We're only interested in responses to the request in question.
-                if p.packet_type == PACKET.RESPONSE and p.response == RETURN_CODE.OK and len(p.response_data) == 4:
+                if packet.packet_type == PACKET.RESPONSE and packet.response == RETURN_CODE.OK and len(packet.response_data) == 4:
                     # Base ID is set in the response data.
-                    self._base_id = p.response_data
+                    self._base_id = packet.response_data
                     break
             except queue.Empty:
                 continue
         # Return the current Base ID (might be None).
         return self._base_id
+
+    @base_id.setter
+    def base_id(self, base_id):
+        ''' Sets the Base ID manually, only for testing purposes. '''
+        self._base_id = base_id

--- a/enocean/communicators/communicator.py
+++ b/enocean/communicators/communicator.py
@@ -18,7 +18,7 @@ class Communicator(threading.Thread):
     '''
     logger = logging.getLogger('enocean.communicators.Communicator')
 
-    def __init__(self, callback=None, learn_in=True):
+    def __init__(self, callback=None, teach_in=True):
         super(Communicator, self).__init__()
         # Create an event to stop the thread
         self._stop_flag = threading.Event()
@@ -33,7 +33,7 @@ class Communicator(threading.Thread):
         self._base_id = None
         # Should new messages be learned automatically? Defaults to True.
         # TODO: Not sure if we should use CO_WR_LEARNMODE??
-        self.learn_in = learn_in
+        self.teach_in = teach_in
 
     def _get_from_send_queue(self):
         ''' Get message from send queue, if one exists '''

--- a/enocean/protocol/EEP.xml
+++ b/enocean/protocol/EEP.xml
@@ -316,6 +316,29 @@
           <item description="Actuator External Interface Settings Query" value="12" />
           <item description="Actuator External Interface Settings Response" value="13" />
         </command>
+        <data command="1" bits="3">
+          <enum description="Command indentifier" shortcut="CMD" offset="4" size="4">
+            <rangeitem description="Command ID {value}" start="0" end="13" />
+          </enum>
+          <enum description="Dim value" shortcut="DV" offset="8" size="3">
+            <item description="Switch to new output value" value="0" />
+            <item description="Dim to new output level - dim timer 1" value="1" />
+            <item description="Dim to new output level - dim timer 2" value="2" />
+            <item description="Dim to new output level - dim timer 3" value="3" />
+            <item description="Stop dimming" value="4" />
+          </enum>
+          <enum description="I/O channel" shortcut="IO" offset="11" size="5">
+            <rangeitem description="Output channel {value} (to load)" start="0" end="29" />
+            <item description="All output channels supported by the device" value="30" />
+            <item description="Input channel (from mains supply)" value="31" />
+          </enum>
+          <enum description="Output value" shortcut="OV" offset="17" size="7">
+            <item description="Output value 0% or OFF" value="0" />
+            <rangeitem description="Output value {value}% or ON" start="1" end="100" />
+            <item description="Not used" start="101" end="126" />
+            <item description="output value not valid / not set" value="127" />
+          </enum>
+        </data>
         <data command="4" bits="3">
           <enum description="Power Failure" shortcut="PF" offset="0" size="1">
             <item description="Power Failure Detection disabled/not supported" value="0" />

--- a/examples/example_DO21-11B-E.py
+++ b/examples/example_DO21-11B-E.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+'''
+Example to show automatic UTE Teach-in responses using
+http://www.g-media.fr/prise-gigogne-enocean.html
+
+Waits for UTE Teach-ins, sends the response automatically and prints the ID of new device.
+'''
+
+import sys
+import time
+import traceback
+import enocean.utils
+from enocean.communicators import SerialCommunicator
+from enocean.protocol.packet import RadioPacket, UTETeachIn
+from enocean.protocol.constants import RORG
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+
+
+def send_command(destination, output_value):
+    global communicator
+    communicator.send(
+        RadioPacket.create(rorg=RORG.VLD, rorg_func=0x01, rorg_type=0x01, destination=destination, sender=communicator.base_id, command=1, IO=0x1E, OV=output_value)
+    )
+
+
+def turn_on(destination):
+    send_command(destination, 100)
+
+
+def turn_off(destination):
+    send_command(destination, 0)
+
+
+communicator = SerialCommunicator()
+communicator.start()
+print('The Base ID of your module is %s.' % enocean.utils.to_hex_string(communicator.base_id))
+
+# Example of turning switches on and off
+turn_on([0x01, 0x94, 0xB9, 0x46])
+# Needs a bit of sleep in between, working too fast :S
+time.sleep(0.1)
+turn_on([0x01, 0x94, 0xE3, 0xB9])
+time.sleep(1)
+
+turn_off([0x01, 0x94, 0xB9, 0x46])
+time.sleep(0.1)
+turn_off([0x01, 0x94, 0xE3, 0xB9])
+
+
+print('Press and hold the teach-in button on the plug now, till it starts turning itself off and on (about 10 seconds or so...)')
+devices_learned = []
+
+# endless loop receiving radio packets
+while communicator.is_alive():
+    try:
+        # Loop to empty the queue...
+        packet = communicator.receive.get(block=True, timeout=1)
+        if isinstance(packet, UTETeachIn):
+            print('New device learned! The ID is %s.' % (packet.sender_hex))
+            devices_learned.append(packet.sender)
+    except queue.Empty:
+        continue
+    except KeyboardInterrupt:
+        break
+    except Exception:
+        traceback.print_exc(file=sys.stdout)
+        break
+
+print('Devices learned during this session: %s' % (', '.join([enocean.utils.to_hex_string(x) for x in devices_learned])))
+
+if communicator.is_alive():
+    communicator.stop()

--- a/tests/test_packet_creation.py
+++ b/tests/test_packet_creation.py
@@ -276,3 +276,25 @@ def test_packets_with_destination():
     assert len(packet_serialized) == len(MAGNETIC_SWITCH)
     assert list(packet_serialized) == list(MAGNETIC_SWITCH)
     assert packet.learn is False
+
+
+@timing(1000)
+def test_vld():
+    SWITCH = bytearray([
+        0x55,
+        0x00, 0x09, 0x07, 0x01,
+        0x56,
+        0xD2, 0x01, 0x1E, 0x64, 0xDE, 0xAD, 0xBE, 0xEF, 0x00,
+        0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00,
+        0x5A
+    ])
+    packet = RadioPacket.create(rorg=RORG.VLD, rorg_func=0x01, rorg_type=0x01, command=1, CMD=1, DV=0, IO=0x1E, OV=0x64)
+    packet_serialized = packet.build()
+
+    assert len(packet_serialized) == len(SWITCH)
+    assert list(packet_serialized) == list(SWITCH)
+    assert packet.parsed['CMD']['raw_value'] == 0x01
+    assert packet.parsed['IO']['raw_value'] == 0x1E
+    assert packet.parsed['IO']['value'] == 'All output channels supported by the device'
+    assert packet.parsed['DV']['value'] == 'Switch to new output value'
+    assert packet.parsed['OV']['value'] == 'Output value 100% or ON'

--- a/tests/test_teachin.py
+++ b/tests/test_teachin.py
@@ -1,30 +1,43 @@
 # -*- encoding: utf-8 -*-
 from __future__ import print_function, unicode_literals, division, absolute_import
 
+from enocean.communicators import Communicator
 from enocean.protocol.packet import Packet
-from enocean.protocol.constants import RORG
+from enocean.protocol.constants import RORG, DB6
 from .decorators import timing
 
 
 @timing(rounds=100, limit=0.2)
 def test_ute_in():
-    # ['0xd4', '0xa0', '0xff', '0x3e', '0x0', '0x1', '0x1', '0xd2', '0x1', '0x94', '0xe3', '0xb9', '0x0'] ['0x1', '0xff', '0xff', '0xff', '0xff', '0x40', '0x0']
-    status, buf, p = Packet.parse_msg(bytearray([
-        0x55,
-        0x00, 0x0D, 0x07, 0x01,
-        0xFD,
-        0xD4, 0xA0, 0xFF, 0x3e, 0x00, 0x01, 0x01, 0xD2, 0x01, 0x94, 0xE3, 0xB9, 0x00,
-        0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x40, 0x00,
-        0xAB
-    ]))
-    assert p.sender_hex == '01:94:E3:B9'
-    assert p.unidirectional is False
-    assert p.bidirectional is True
-    assert p.response_expected is True
-    assert p.number_of_channels == 0xFF
-    assert p.rorg_manufacturer == 0x3E
-    assert p.rorg_of_eep == RORG.VLD
-    assert p.rorg_func == 0x01
-    assert p.rorg_type == 0x01
-    assert p.teach_in is True
-    assert p.delete is False
+    communicator = Communicator()
+    communicator.base_id = [0xDE, 0xAD, 0xBE, 0xEF]
+
+    status, buf, packet = Packet.parse_msg(
+        bytearray([
+            0x55,
+            0x00, 0x0D, 0x07, 0x01,
+            0xFD,
+            0xD4, 0xA0, 0xFF, 0x3E, 0x00, 0x01, 0x01, 0xD2, 0x01, 0x94, 0xE3, 0xB9, 0x00,
+            0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x40, 0x00,
+            0xAB
+        ]),
+        communicator=communicator
+    )
+
+    assert packet.sender_hex == '01:94:E3:B9'
+    assert packet.unidirectional is False
+    assert packet.bidirectional is True
+    assert packet.response_expected is True
+    assert packet.number_of_channels == 0xFF
+    assert packet.rorg_manufacturer == 0x3E
+    assert packet.rorg_of_eep == RORG.VLD
+    assert packet.rorg_func == 0x01
+    assert packet.rorg_type == 0x01
+    assert packet.teach_in is True
+    assert packet.delete is False
+
+    response_packet = packet._create_response_packet(communicator.base_id)
+    assert response_packet.sender_hex == 'DE:AD:BE:EF'
+    assert response_packet.destination_hex == '01:94:E3:B9'
+    assert response_packet._bit_data[DB6.BIT_5:DB6.BIT_3] == [False, True]
+    assert response_packet.data[2:7] == packet.data[2:7]


### PR DESCRIPTION
Can anyone think of why we shouldn't respond to teach-in messages automatically?
With the current implementation, it defaults to sending the automatic responses. Disabling this can be done by setting `Communicator.teach-in` to False.