### PR TITLE
[add] EEP.xml: Mechanical Window handle (F6-10-00)

### DIFF
--- a/enocean/protocol/EEP.xml
+++ b/enocean/protocol/EEP.xml
@@ -42,6 +42,20 @@
         </data>
       </profile>
     </profiles>
+    <profiles func="0x10" description="Mechanical Handle">
+      <profile type="0x00" description="Window Handle">
+        <data>
+          <enum description="Window handle" shortcut="WIN" offset="2" size="2">
+            <item description="Moved from up to vertical" value="0" />
+            <item description="Moved from vertical to up" value="1" />
+            <item description="Moved from down to vertical" value="2" />
+            <item description="Moved from vertical to down" value="3" />
+          </enum>
+          <status description="T21" shortcut="T21" offset="2" size="1" />
+          <status description="NU" shortcut="NU" offset="3" size="1" />
+        </data>
+      </profile>
+    </profiles>
   </telegram>
   <telegram rorg="0xD5" type="1BS" description="1BS Telegram">
     <profiles func="0x00" description="Contacts and Switches">


### PR DESCRIPTION
Added the Hoppe mechanical window handle to the EEP.xml
I tried to follow the EEP (2.6.4) as good as possible. But this profile was rather strange. (it even has a typo in it. First entry should be 'Moved from up to right')
I don't kow if you are happy with the long description strings. If i had designed this profile it would just have 3 states:
- top
- vertical
- down

But Hoppe somehow decided to more describe the movement of the handle than the state.

Tested with Hoppe SecuSignal handle