### PR TITLE
[fix] correct scale for a5-10-03 room operating panel

### DIFF
--- a/enocean/protocol/EEP.xml
+++ b/enocean/protocol/EEP.xml
@@ -471,8 +471,8 @@
               <max>255</max>
             </range>
             <scale>
-              <min>-100</min>
-              <max>100</max>
+              <min>0</min>
+              <max>255</max>
             </scale>
           </value>
           <value shortcut="TMP" description="Temperature (linear)" offset="16" size="8" unit="°C">


### PR DESCRIPTION
Following the EEP 2.6.4, i corrected the scale for the room operating panel.

![image](https://cloud.githubusercontent.com/assets/13163514/21772519/ebf7a5a4-d68b-11e6-92f0-6ae89bb1bfaf.png)
