### PR TITLE
RPS type packet is not learn by default

### DIFF
--- a/enocean/protocol/packet.py
+++ b/enocean/protocol/packet.py
@@ -342,6 +342,8 @@ class RadioPacket(Packet):
                     self.rorg_type = enocean.utils.from_bitarray(self._bit_data[DB3.BIT_1:DB2.BIT_2])
                     self.rorg_manufacturer = enocean.utils.from_bitarray(self._bit_data[DB2.BIT_2:DB0.BIT_7])
                     self.logger.debug('learn received, EEP detected, RORG: 0x%02X, FUNC: 0x%02X, TYPE: 0x%02X, Manufacturer: 0x%02X' % (self.rorg, self.rorg_func, self.rorg_type, self.rorg_manufacturer))
+        if self.rorg == RORG.RPS:
+            self.learn = False
 
         return super(RadioPacket, self).parse()
 


### PR DESCRIPTION
Using the PTM215 DB 4 way switch was not possible because it would only recognize teach in packets
This fixes #53