### PR TITLE
Set packet data/optional default value in create()

### DIFF
--- a/enocean/protocol/packet.py
+++ b/enocean/protocol/packet.py
@@ -204,7 +204,7 @@ class Packet(object):
         if not isinstance(sender, list) or len(sender) != 4:
             raise ValueError('Sender must a list containing 4 (numeric) values.')
 
-        packet = Packet(packet_type)
+        packet = Packet(packet_type, data=[], optional=[])
         packet.rorg = rorg
         packet.data = [packet.rorg]
         # Select EEP at this point, so we know how many bits we're dealing with (for VLD).


### PR DESCRIPTION
Calling the ```Packet.create()``` method causes the logger to emit warnings about using default values for ```Packet.data``` and ```Packet.optional``` when instantiating the new packet.
This uses the default value ```[]``` explicitly to stop the warnings.