### PR TITLE
Fixed logging imports when file is required

### DIFF
--- a/enocean/consolelogger.py
+++ b/enocean/consolelogger.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 from __future__ import print_function, unicode_literals, division, absolute_import
 import logging
-
+import logging.handlers
 
 def init_logging(level=logging.DEBUG, log_to_file=False, logsize=1024, logcount=5):
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
logging.handlers wasn't properly imported. They have to be imported implicitly.