### PR TITLE
add callback-property

### DIFF
--- a/enocean/communicators/communicator.py
+++ b/enocean/communicators/communicator.py
@@ -81,6 +81,14 @@ class Communicator(threading.Thread):
                     self.__callback(packet)
                 self.logger.debug(packet)
 
+    @property  # getter
+    def callback(self):
+        return self.__callback
+
+    @callback.setter
+    def callback(self, callback):
+        self.__callback = callback
+
     @property
     def base_id(self):
         ''' Fetches Base ID from the transmitter, if required. Otherwise returns the currently set Base ID. '''


### PR DESCRIPTION
The property is necessary because i want to add teach-in support in the home assistant project. I already implemented the code, but without this property i would have to access a protected member of the communicator. This prevents me from pushing my changes to the home assistant project.