### PR TITLE
Support for CO2 Devices (EEP - A5-09-09)

### DIFF
--- a/enocean/protocol/EEP.xml
+++ b/enocean/protocol/EEP.xml
@@ -745,6 +745,20 @@
           </enum>
         </data>
       </profile>
+      <profile description="Gas Sensor" type="0x09">
+        <data>
+          <value shortcut="CO2", description="CO2 Measurement" offset="16" size="8" unit="ppm">
+            <range>
+              <min>0</min>
+              <max>255</max>
+            </range>
+            <scale>
+              <min>0</min>
+              <max>2000</max>
+            </scale>   
+          </value>
+        </data>
+      </profile>
     </profiles>
     <profiles func="0x10" description="Room Operating Panel">
       <profile type="0x03" description="Temperature Sensor and Set Point">


### PR DESCRIPTION
With this addition to EEP.xml file,

Library will be able to serialize devices that supports [A5-09-09](http://tools.enocean-alliance.org/EEPViewer/profiles/A5/09/09/A5-09-09.pdf) profile as well.

Like this device,
https://www.enocean-alliance.org/product/afriso_co2sensor-f/
